### PR TITLE
Fix path to favicon.ico according with the index.html appears not in /

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Protocol Writer</title>
-    <link rel="shortcut icon" type="image/ico" href="/favicon.ico"/>
+    <link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,700,700i" rel="stylesheet">
     <link href="./css/lemon.min.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Protocol Writer</title>
-    <link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
+    <link rel="shortcut icon" type="image/ico" href="./favicon.ico"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,700,700i" rel="stylesheet">
     <link href="./css/lemon.min.css" rel="stylesheet">


### PR DESCRIPTION
The problem is that the `index.html` appears at `https://avito-tech.github.io/protocol-writer/`. So, you are to seek `favicon.ico` at `/protocol-writer` or at relative path, as I'm suggesting. The absolute path '/favicon.ico' doesn't work. You can make sure of it just  [opening the App](https://avito-tech.github.io/protocol-writer/).