### PR TITLE
Set actual record time for last item

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,10 @@ new Vue({
         if (this.isDark) {
             document.body.classList.add("dark-theme")
         }
+        // set actual record time for last item
+        setInterval(() => {
+            this.log[this.log.length-1].date = new Date();
+        }, 1000)
     },
     methods: {
         removeLine() {
@@ -39,8 +43,6 @@ new Vue({
             }, 1000);
         },
         append() {
-            // set actual record time for last item
-            this.log[this.log.length-1].date = new Date();
             this.log = this.log.concat([newLogItem()]);
             this.persist();
             setTimeout(() => {

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,8 @@ new Vue({
             }, 1000);
         },
         append() {
+            // set actual record time for last item
+            this.log[this.log.length-1].date = new Date();
             this.log = this.log.concat([newLogItem()]);
             this.persist();
             setTimeout(() => {


### PR DESCRIPTION
Currently, the timestamp for a specific entry is calculated at the moment the placeholder with empty content is created and is ultimately recorded as is.

These changes update the timestamp at the moment the entry itself is created.